### PR TITLE
namespace honeycomb exporter

### DIFF
--- a/src/otelcollector/otelcol-config-extras.yml
+++ b/src/otelcollector/otelcol-config-extras.yml
@@ -2,15 +2,20 @@
 # do not delete this file
 
 exporters:
-  otlp:
+  otlp/honeycomb:
     endpoint: "api.honeycomb.io:443"
     headers:
       "x-honeycomb-team": "<HONEYCOMB_API_KEY>"
       "x-honeycomb-dataset": "webstore-metrics"
-
 service:
   pipelines:
-    traces:
-      exporters: [otlp, jaeger]
     metrics:
-      exporters: [otlp, prometheus]
+      exporters:
+        - prometheus
+        - logging
+        - otlp/honeycomb
+    traces:
+      exporters:
+        - otlp
+        - logging
+        - otlp/honeycomb


### PR DESCRIPTION
Since upstream now uses OTLP to talk to Jaeger instead of Jaeger exporter.  This namespaces the Honeycomb OTLP exporter and references the proper receivers from the main config.